### PR TITLE
Removing order dependency of `test_remove_bookmark`

### DIFF
--- a/tests/test_marlin.py
+++ b/tests/test_marlin.py
@@ -32,6 +32,7 @@ def test_list_bookmark():
 
 
 def test_remove_bookmark():
+    mock_object.add_bookmark()
     mock_object.remove_bookmark()
     bookmark = Path((marlin_path) / 'mock')
     exists = Path(bookmark).exists()


### PR DESCRIPTION
This PR aims to improve test reliability by removing order dependency of `test_remove_bookmark`, by calling `add_bookmark` before executing `remove_bookmark`.

The test would fail in this way if order dependency is not removed:
```
>       mock_object.remove_bookmark()
tests/test_marlin.py:36: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <marlin.manage.ManageBookmark object at 0x7fa8a5f29580>

    def remove_bookmark(self):
        os.chdir(self.m_path)
>       os.unlink(self.bookmark_name)
E       FileNotFoundError: [Errno 2] No such file or directory: 'mock'
```